### PR TITLE
Use threads in imdb and subtitles plugins for IO ops

### DIFF
--- a/src/video/plugins/imdb.py
+++ b/src/video/plugins/imdb.py
@@ -46,6 +46,7 @@ __license__          = 'GPL'
 # Module Imports
 import os
 
+import kaa
 import menu
 import config
 import plugin
@@ -145,7 +146,11 @@ class PluginInterface(plugin.ItemPlugin):
     
         try:
             #guess the title from the filename
-            results = self.fxd.guessImdb(self.searchstring, self.disc_set)
+            lock = kaa.ThreadCallable(self.fxd.guessImdb, 
+                                      self.searchstring, 
+                                      self.disc_set)()
+            lock.wait()
+            results = lock.result            
             
             # loop through the results and create menu
             # should not use imdbpy objects here as imdbpy should be encapsulated by FxdImdb
@@ -214,7 +219,11 @@ class PluginInterface(plugin.ItemPlugin):
         dlg = dialog.show_working_indicator(_('Getting data...'))
 
         try:
-            self.fxd.retrieveImdbData(arg[0], self.fxd.ctitle[1], self.fxd.ctitle[2])
+            lock = kaa.ThreadCallable(self.fxd.retrieveImdbData, 
+                arg[0], 
+                self.fxd.ctitle[1], 
+                self.fxd.ctitle[2])()
+            lock.wait() 
 
         except FxdImdb_Error, error:
             logger.warning('%s', error)

--- a/src/video/plugins/subtitles/__init__.py
+++ b/src/video/plugins/subtitles/__init__.py
@@ -62,6 +62,7 @@ import os
 import glob
 from operator import itemgetter, attrgetter
 
+import kaa
 import menu
 import config
 import plugin
@@ -339,9 +340,17 @@ class PluginInterface(plugin.ItemPlugin):
 
                 if self.item.subitems:
                     for i in range(len(self.item.subitems)):
-                        self.subs.update(handler.get_subs(self.item.subitems[i].filename, config.SUBS_LANGS.keys()))
+                        lock = kaa.ThreadCallable(handler.get_subs, 
+                                                  self.item.subitems[i].filename, 
+                                                  config.SUBS_LANGS.keys())()
+                        lock.wait()
+                        self.subs.update(lock.result)
                 else:
-                    self.subs.update(handler.get_subs(self.item.filename, config.SUBS_LANGS.keys()))
+                    lock = kaa.ThreadCallable(handler.get_subs, 
+                                              self.item.filename, 
+                                              config.SUBS_LANGS.keys())()
+                    lock.wait()
+                    self.subs.update(lock.result)
 
                 dlg.hide()
 


### PR DESCRIPTION
Added ThreadCallable wrapper for all IO calls in xbmc and subtitles plugins. This allows proper operations of dialog.show_working_indicator() as the main thread does not block on IO which allows timer to operate.
